### PR TITLE
Update interpreter.asm

### DIFF
--- a/interpreter.asm
+++ b/interpreter.asm
@@ -23,8 +23,25 @@
 ; QUIT INTERPRET FIND FIND-NAME >CFA PARSE-NAME WORD EXECUTE EVALUATE ' ABORT /STRING
 
 restore_handler
-    cli
-    jmp QUIT
+   pha				; save a
+   txa				; copy x
+   pha				; save x
+   tya				; copy y
+   pha				; save y
+   lda	#$7f			; disable all interrupts
+   sta	$dd0d		        ; 
+   ldy	$dd0d		        ; save cia 2 icr
+   bpl stop_restore             ; if high bit not set
+
+kernal_nmi
+   jmp $fe72
+
+stop_restore
+   jsr	$f6bc		; increment real time clock
+   jsr	$ffe1		; scan stop key
+   bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
+   
+   jmp QUIT    
 
 quit_reset
     sei


### PR DESCRIPTION
  Where there a will, there's a way.

Again: This avoids rom cart init- passes through non-CIA NMI's (Restore) silently, and executes quit at run/stop Restore.